### PR TITLE
Allow verify_ssl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,13 @@ The above command adds below section to your profile::
     dynamodb =
         endpoint_url = http://localhost:8000
 
+To allow insecure/self-signed ssl certificates::
+
+    [profile local]
+    dynamodb =
+        verify_ssl = false
+        endpoint_url = https://localhost:8000
+
 Now you can access your local dynamodb just use profile::
 
     $ aws dynamodb list-tables --profile local

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,10 @@ To allow insecure/self-signed ssl certificates::
         verify_ssl = false
         endpoint_url = https://localhost:8000
 
+To disable Unverified HTTPS request warning, export::
+
+    export PYTHONWARNINGS="ignore:Unverified HTTPS request"
+
 Now you can access your local dynamodb just use profile::
 
     $ aws dynamodb list-tables --profile local

--- a/awscli_plugin_endpoint/__init__.py
+++ b/awscli_plugin_endpoint/__init__.py
@@ -1,4 +1,15 @@
 ENDPOINT_URL = 'endpoint_url'
+VERIFY_SSL = 'verify_ssl'
+
+def str2bool(value):
+    return str(value).lower() in ['1', 'yes', 'y', 'true', 'on']
+
+def get_verify_from_profile(profile, command):
+    verify = True
+    if command in profile:
+        if VERIFY_SSL in profile[command]:
+            verify = str2bool(profile[command][VERIFY_SSL])
+    return verify
 
 def get_endpoint_from_profile(profile, command):
     endpoint = None
@@ -20,5 +31,21 @@ def set_endpoint_from_profile(parsed_args, **kwargs):
         if service_endpoint is not None:
             parsed_args.endpoint_url = service_endpoint
 
+def set_verify_from_profile(parsed_args, **kwargs):
+    verify_ssl = parsed_args.verify_ssl
+    command = parsed_args.command
+    # By default verify_ssl is set to true
+    # if --no-verify-ssl is specified, parsed_args.verify_ssl is False
+    # so keep it
+    if verify_ssl:
+        session = kwargs['session']
+        # Set profile to session so we can load profile from config
+        if parsed_args.profile:
+            session.set_config_variable('profile', parsed_args.profile)
+        service_verify = get_verify_from_profile(session.get_scoped_config(), command)
+        if service_verify is not None:
+            parsed_args.verify_ssl = service_verify
+
 def awscli_initialize(cli):
     cli.register('top-level-args-parsed', set_endpoint_from_profile)
+    cli.register('top-level-args-parsed', set_verify_from_profile)


### PR DESCRIPTION
If the endpoint is insecure, allow verify_ssl option, --no-verify-ssl on CLI.