### PR TITLE
README.rst is now README.md

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=['awscli_plugin_endpoint'],
     version='0.2',
     description='Endpoint plugin for AWS CLI',
-    long_description=open('README.rst').read(),
+    long_description=open('README.md').read(),
     author='Bruce Li',
     author_email='wbinglee@gmail.com',
     url='https://github.com/wbinglee/awscli-plugin-endpoint',


### PR DESCRIPTION
See 7397ebf084ec56fe677d8946170adace0d162ae3

Otherwise, installation bombs out with
```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File ".../awscli-plugin-endpoint/setup.py", line 12, in <module>
        long_description=open('README.rst').read(),
    IOError: [Errno 2] No such file or directory: 'README.rst'
```