### PR TITLE
Add universal=True to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[bdist_wheel]
+universal = True


### PR DESCRIPTION
Documentation: https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

This essentially indicates that users of this package don't have to build separate wheels for python 2 vs python 3 or for different operating systems.